### PR TITLE
Save after every history addition.

### DIFF
--- a/sample.tclshrc
+++ b/sample.tclshrc
@@ -58,6 +58,10 @@ if {$tcl_interactive} {
     #
     # ::tclreadline::readline customcompleter ""
 
+    # automatically save the history after every
+    # command (instead of when cleanly exiting)
+    set tclreadline::autosave 1
+
     # go to tclrealdine's main loop.
     #
     tclreadline::Loop

--- a/tclreadlineSetup.tcl.in
+++ b/tclreadlineSetup.tcl.in
@@ -289,7 +289,8 @@ namespace eval tclreadline {
                 if {[string length $::tclreadline::LINE]
                         && [history event 0] != $::tclreadline::LINE} {
                     history add $::tclreadline::LINE
-                    if {[info exists ::tclreadline::autosave] && $::tclreadline::autosave == 1 && \
+                    if {[info exists ::tclreadline::autosave] && \
+			    [string is true -strict $::tclreadline::autosave] && \
 			    [catch {::tclreadline::readline write [::tclreadline::HistoryFileGet]} \
                              ::tclreadline::errorMsg]} {
                         puts stderr $::tclreadline::errorMsg

--- a/tclreadlineSetup.tcl.in
+++ b/tclreadlineSetup.tcl.in
@@ -289,6 +289,10 @@ namespace eval tclreadline {
                 if {[string length $::tclreadline::LINE]
                         && [history event 0] != $::tclreadline::LINE} {
                     history add $::tclreadline::LINE
+                    if {[catch {::tclreadline::readline write [::tclreadline::HistoryFileGet]} \
+                             ::tclreadline::errorMsg]} {
+                        puts stderr $::tclreadline::errorMsg
+                    }
                 }
 
                 if {[catch {

--- a/tclreadlineSetup.tcl.in
+++ b/tclreadlineSetup.tcl.in
@@ -289,7 +289,8 @@ namespace eval tclreadline {
                 if {[string length $::tclreadline::LINE]
                         && [history event 0] != $::tclreadline::LINE} {
                     history add $::tclreadline::LINE
-                    if {[catch {::tclreadline::readline write [::tclreadline::HistoryFileGet]} \
+                    if {[info exists ::tclreadline::autosave] && $::tclreadline::autosave == 1 && \
+			    [catch {::tclreadline::readline write [::tclreadline::HistoryFileGet]} \
                              ::tclreadline::errorMsg]} {
                         puts stderr $::tclreadline::errorMsg
                     }


### PR DESCRIPTION
Hi,
I find this very useful at work as it means I can run a while {1} {..} loop and ctrl-c it but still have the history for next time.
Also very useful when debugging crashy extensions.