### PR TITLE
free-fix for non-braced ifs

### DIFF
--- a/tclreadline.c
+++ b/tclreadline.c
@@ -47,7 +47,7 @@ static const char* tclrl_version_str = TCLRL_VERSION_STR;
 static const char* tclrl_patchlevel_str = TCLRL_PATCHLEVEL_STR;
 
 #define MALLOC(size) malloc(size)
-#define FREE(ptr) free(ptr); ptr = NULL
+#define FREE(ptr) do {free(ptr); ptr = NULL;} while (0)
 
 enum {
     _CMD_SET = (1 << 0),


### PR DESCRIPTION
the original FREE define does not work correctly in cases of

if (condition) FREE(x);

as the second operation (ptr = NULL) is then uncoditionally executed.
My current gcc warned about this.