### PR TITLE
autogen.sh: Honor NOCONFIGURE

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -47,11 +47,6 @@ test $TEST_TYPE $FILE || {
     exit 1
 }
 
-if test -z "$*"; then
-    echo "I am going to run ./configure with no arguments - if you wish "
-    echo "to pass any to it, please specify them on the $0 command line."
-fi
-
 case $CC in
     *xlc | *xlc\ * | *lcc | *lcc\ *)
         am_opt=--include-deps
@@ -67,5 +62,12 @@ automake -a $am_opt
 autoconf
 cd $ORIGDIR
 
-$srcdir/configure --enable-maintainer-mode "$@"
+if test -z "$NOCONFIGURE"; then
+    if test -z "$*"; then
+        echo "I am going to run ./configure with no arguments - if you wish "
+        echo "to pass any to it, please specify them on the $0 command line."
+    fi
+
+    $srcdir/configure --enable-maintainer-mode "$@"
+fi
 


### PR DESCRIPTION
Linux distros will usually want to run configure separately so the script should respect their wishes. See also https://people.gnome.org/~walters/docs/build-api.txt