### PR TITLE
User defined history file

### DIFF
--- a/tclreadlineSetup.tcl.in
+++ b/tclreadlineSetup.tcl.in
@@ -219,7 +219,7 @@ namespace eval tclreadline {
                 set historyfile [lindex $args 0]
             }
         } elseif {[info exists env(TCL_HISTORY_FILE)]} {
-            set historyfile $env(HOME)/$env(TCL_HISTORY_FILE)
+            set historyfile $env(TCL_HISTORY_FILE)
         } else {
             if {[info exists env(HOME)]} {
                 set historyfile $env(HOME)/.tclsh-history

--- a/tclreadlineSetup.tcl.in
+++ b/tclreadlineSetup.tcl.in
@@ -218,6 +218,8 @@ namespace eval tclreadline {
             if {"" == [string trim $historyfile]} {
                 set historyfile [lindex $args 0]
             }
+        } elseif {[info exists env(TCL_HISTORY_FILE)]} {
+            set historyfile $env(HOME)/$env(TCL_HISTORY_FILE)
         } else {
             if {[info exists env(HOME)]} {
                 set historyfile $env(HOME)/.tclsh-history


### PR DESCRIPTION
This minor non-breaking addition allows the user to specify  an alternative name for the history file. This is very useful for embedded interpreters. This way, the .tclsh-history file won't be cluttered by application-specific commands, which are not
know for /usr/bin/tclsh.