### PR TITLE
Update tclreadlineInit.tcl.in

### DIFF
--- a/tclreadlineInit.tcl.in
+++ b/tclreadlineInit.tcl.in
@@ -17,7 +17,11 @@ proc ::tclreadline::Init {} {
     uplevel #0 {
         if {![info exists tclreadline::library]} {
             set msg ""
-            foreach dirname [list @TCLRL_LIBDIR@ [file dirname [info script]]] {
+            set libsList [list @TCLRL_LIBDIR@ [file dirname [info script]]]
+            switch -- $tcl_platform(os) {
+                Linux {lappend libsList /usr/lib /usr/lib64}
+            }
+            foreach dirname $libsList {
                 if {[catch {load [file join $dirname libtclreadline[info sharedlibextension]]} msg] == 0} {
                     set msg ""
                     break


### PR DESCRIPTION
In 64-bit linux system, standart library path is /usr/lib64 and library tclreadline.so placed correctly by installer, but installer incorrect configure tclreadlineInit.tcl script, which find library in /usr/lib.
Correct way - to change installer (Makefile or configure.in file) for correct path in @TCLRL_LIBDIR@, but easy way - correct this file.
This patch add standart hardcoded library path, depending to platform.