### PR TITLE
Fix pkg load on 8.7

### DIFF
--- a/tclreadlineInit.tcl.in
+++ b/tclreadlineInit.tcl.in
@@ -18,7 +18,7 @@ proc ::tclreadline::Init {} {
         if {![info exists tclreadline::library]} {
             set msg ""
             foreach dirname [list @TCLRL_LIBDIR@ [file dirname [info script]]] {
-                if {[catch {load [file join $dirname libtclreadline[info sharedlibextension]] tclreadline} msg] == 0} {
+                if {[catch {load [file join $dirname libtclreadline[info sharedlibextension]] Tclreadline} msg] == 0} {
                     set msg ""
                     break
                 }

--- a/tclreadlineInit.tcl.in
+++ b/tclreadlineInit.tcl.in
@@ -18,7 +18,7 @@ proc ::tclreadline::Init {} {
         if {![info exists tclreadline::library]} {
             set msg ""
             foreach dirname [list @TCLRL_LIBDIR@ [file dirname [info script]]] {
-                if {[catch {load [file join $dirname libtclreadline[info sharedlibextension]]} msg] == 0} {
+                if {[catch {load [file join $dirname libtclreadline[info sharedlibextension]] tclreadline} msg] == 0} {
                     set msg ""
                     break
                 }


### PR DESCRIPTION
Tcl 8.6 (and 8.5 as far as I can remember) used to infer the name of
this package as Tclreadline.
In Tcl 8.7, the algorithm must have changed (I haven't gone through the
TIPs or the commits). The inferred name is now simply Readline. This
breaks loading, as the init prod is Tclreadline_Init.