### PR TITLE
Fix configure.ac compatibility with Clang 16

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -250,7 +250,7 @@ int main (void) {
     FILE *fp = fopen("conftestversion", "w");
     extern char *rl_library_version;
     fprintf(fp, "%s", rl_library_version);
-    close(fp);
+    fclose(fp);
     return 0;
 }],
     READLINE_VERSION=`cat conftestversion`

--- a/configure.ac
+++ b/configure.ac
@@ -245,7 +245,8 @@ AC_TRY_LINK(,[
 AC_MSG_CHECKING([for the readline version number])
 AC_TRY_RUN([
 #include <stdio.h>
-int main () {
+#include <unistd.h>
+int main (void) {
     FILE *fp = fopen("conftestversion", "w");
     extern char *rl_library_version;
     fprintf(fp, "%s", rl_library_version);


### PR DESCRIPTION
Clang 16 makes -Wimplicit-function-declaration and -Wimplicit-int errors by default.

Unfortunately, this can lead to misconfiguration or miscompilation of software as configure
tests may then return the wrong result.

We also fix -Wstrict-prototypes while here as it's easy to do and it prepares
us for C23.

For more information, see LWN.net [0] or LLVM's Discourse [1], the Gentoo wiki [2],
or the (new) c-std-porting mailing list [3].

[0] https://lwn.net/Articles/913505/
[1] https://discourse.llvm.org/t/configure-script-breakage-with-the-new-werror-implicit-function-declaration/65213
[2] https://wiki.gentoo.org/wiki/Modern_C_porting
[3] hosted at lists.linux.dev.

Signed-off-by: Sam James <sam@gentoo.org>