### PR TITLE
Improve BSD editline compatibility

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -9,6 +9,9 @@
 /* Define the name of the executing macro variable in libreadline. */
 #undef EXECUTING_MACRO_NAME
 
+/* Define if rl_extend_line_buffer is resolved in libreadline. */
+#undef EXTEND_LINE_BUFFER
+
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #undef HAVE_DLFCN_H
 

--- a/configure
+++ b/configure
@@ -12696,6 +12696,37 @@ fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
+# check for readline's rl_extend_line_buffer
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for rl_extend_line_buffer() in -lreadline" >&5
+$as_echo_n "checking for rl_extend_line_buffer() in -lreadline... " >&6; }
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+    extern void rl_extend_line_buffer(int len);
+    rl_extend_line_buffer(1);
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; };
+
+$as_echo "#define EXTEND_LINE_BUFFER 1" >>confdefs.h
+
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for the readline version number" >&5
 $as_echo_n "checking for the readline version number... " >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -241,6 +241,18 @@ AC_TRY_LINK(,[
     [ Define if rl_cleanup_after_signal is resolved in libreadline. ]),
     AC_MSG_RESULT(no))
 
+# check for readline's rl_extend_line_buffer
+
+AC_MSG_CHECKING([for rl_extend_line_buffer() in -lreadline])
+AC_TRY_LINK(,[
+    extern void rl_extend_line_buffer(int len);
+    rl_extend_line_buffer(1);
+],
+    AC_MSG_RESULT(yes);
+    AC_DEFINE(EXTEND_LINE_BUFFER, 1,
+    [ Define if rl_extend_line_buffer is resolved in libreadline. ]),
+    AC_MSG_RESULT(no))
+
 
 AC_MSG_CHECKING([for the readline version number])
 AC_TRY_RUN([

--- a/tclreadline.c
+++ b/tclreadline.c
@@ -26,11 +26,13 @@
 #endif
 
 
+#ifdef EXTEND_LINE_BUFFER
 /*
  * this prototype may be missing
  * in readline.h
  */
 void rl_extend_line_buffer(int len);
+#endif
 
 #ifdef EXECUTING_MACRO_HACK
 /**
@@ -700,6 +702,10 @@ TclReadlineCompletion(char* text, int start, int end)
     int status;
     rl_completion_append_character = ' '; /* reset, just in case ... */
 
+    /* Only enable history expansion like '!!<TAB>' if the rl_extend_line_buffer
+     * function is available; e.g. libedit doesn't provide it, and alternative
+     * approaches to replace the line buffer don't give the desired behavior */
+#ifdef EXTEND_LINE_BUFFER
     if (tclrl_use_history_expansion && text && ('!' == text[0]
             || (start && rl_line_buffer[start - 1] == '!' /* for '$' */))) {
         char* expansion = (char*) NULL;
@@ -721,6 +727,7 @@ TclReadlineCompletion(char* text, int start, int end)
         }
         FREE(expansion);
     }
+#endif
 
     if (tclrl_custom_completer) {
         char start_s[BUFSIZ], end_s[BUFSIZ];


### PR DESCRIPTION
Two changes to allow for building/running against the BSD editline library (libedit, see https://www.thrysoee.dk/editline/) instead of GNU readline. Tested with libedit 3.1-20221030 (using configure arguments `--with-readline-includes=/usr/include/editline --with-readline-library='-ledit'`).

Please consider merging.